### PR TITLE
Refactored JS code to use jQuery calls

### DIFF
--- a/DutchTreat/wwwroot/js/index.js
+++ b/DutchTreat/wwwroot/js/index.js
@@ -1,14 +1,17 @@
 ﻿console.log("Hello Pluralsight");
 
-var theForm = document.getElementById("theForm");
-theForm.hidden = true;
+var theForm = $("#theForm");
+theForm.hide();
 
-var button = document.getElementById("buyButton");
+var button = $("#buyButton");
 
-button.addEventListener("click", function () {
+button.on("click", function () {
     console.log("Buying Item");
 });
 
-var productInfo = document.getElementsByClassName("product-props");
+var productInfo = $(".product-props li");
 // Not a good way to list out items in a collection, better way with jquery.
 //var listItems = productInfo.item[0].children;
+productInfo.on("click", function () {
+    console.log("You clicked on " + $(this).text());
+});


### PR DESCRIPTION
able to use `var productInfo = $(".product-props li"); `
instead of printing out array in JS